### PR TITLE
ci: run tests only on pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,6 @@ name: Test
 on:
   pull_request:
     branches: [ main ]
-  push:
-    branches: [ main ]
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- Removed push trigger from test workflow
- Tests will now run only when PRs are created or updated
- This reduces unnecessary CI runs on direct pushes to main

## Test plan
- [x] Verify tests run on this PR
- [ ] Confirm tests don't run on direct pushes after merge

🤖 Generated with [Claude Code](https://claude.ai/code)