### PR TITLE
refactor: remove version and tag options, keep only branch support

### DIFF
--- a/bin/jumon.js
+++ b/bin/jumon.js
@@ -20,9 +20,7 @@ program
   .option('-g, --global', 'Install to global commands (~/.claude/commands/)')
   .option('-l, --local', 'Install to local project (.claude/commands/) [default]')
   .option('-a, --alias <name>', 'Install with a different name')
-  .option('-v, --version <version>', 'Version constraint (e.g., "1.2.0", "~> 1.2.0")')
   .option('-b, --branch <branch>', 'Specific branch to use')
-  .option('-t, --tag <tag>', 'Specific tag to use')
   .action(addCommand);
 
 program

--- a/src/commands/add.js
+++ b/src/commands/add.js
@@ -137,8 +137,8 @@ export async function addCommand(repository, options) {
         
         const revision = await getLatestCommitHash(user, repo);
         
-        const branch = options.branch || options.tag || options.version ? options.branch : 'main';
-        await addRepositoryToConfig(user, repo, filePath, options.alias, options.version, branch, options.tag, isLocal);
+        const branch = options.branch || 'main';
+        await addRepositoryToConfig(user, repo, filePath, options.alias, null, branch, null, isLocal);
         await addRepositoryToLock(user, repo, revision, filePath, isLocal);
         
         console.log(`✓ Successfully installed command '${commandName}' to ${targetFile}`);
@@ -192,8 +192,8 @@ export async function addCommand(repository, options) {
         }
       }
       
-      const branch = options.branch || options.tag || options.version ? options.branch : 'main';
-      await addRepositoryToConfig(user, repo, null, null, options.version, branch, options.tag, isLocal);
+      const branch = options.branch || 'main';
+      await addRepositoryToConfig(user, repo, null, null, null, branch, null, isLocal);
       await addRepositoryToLock(user, repo, revision, null, isLocal);
       console.log(`✓ Successfully installed ${files.length} commands from ${user}/${repo}`);
       console.log(`  Repository: ${user}/${repo}@${revision.substring(0, 7)}`);

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -62,22 +62,9 @@ export async function addRepositoryToConfig(user, repo, commandPath = null, alia
     };
   }
   
-  // Add version/branch/tag constraints (only if provided)
-  if (version) {
-    config.repositories[repoKey].version = version;
-    // Remove branch/tag if version is specified
-    delete config.repositories[repoKey].branch;
-    delete config.repositories[repoKey].tag;
-  } else if (tag) {
-    config.repositories[repoKey].tag = tag;
-    // Remove branch/version if tag is specified
-    delete config.repositories[repoKey].branch;
-    delete config.repositories[repoKey].version;
-  } else if (branch) {
+  // Add branch constraint (only if provided)
+  if (branch) {
     config.repositories[repoKey].branch = branch;
-    // Remove version/tag if branch is specified
-    delete config.repositories[repoKey].version;
-    delete config.repositories[repoKey].tag;
   }
   
   if (commandPath) {

--- a/tests/commands/add.test.js
+++ b/tests/commands/add.test.js
@@ -69,7 +69,7 @@ describe('Add Command', () => {
       expect(mockedPaths.ensureCommandsDir).toHaveBeenCalledWith(true);
       expect(mockedGithub.getFileContent).toHaveBeenCalledWith('testuser', 'testrepo', 'test.md');
       expect(mockedFs.writeFile).toHaveBeenCalledWith('/test/commands/testuser/testrepo/test.md', '# Test Command\nTest content');
-      expect(mockedConfig.addRepositoryToConfig).toHaveBeenCalledWith('testuser', 'testrepo', 'test.md', undefined, undefined, 'main', undefined, true);
+      expect(mockedConfig.addRepositoryToConfig).toHaveBeenCalledWith('testuser', 'testrepo', 'test.md', undefined, null, 'main', null, true);
       expect(consoleSpy).toHaveBeenCalledWith("✓ Successfully installed command 'test' to /test/commands/testuser/testrepo/test.md");
     });
 
@@ -78,7 +78,7 @@ describe('Add Command', () => {
 
       await addCommand('testuser/testrepo/test', options);
 
-      expect(mockedConfig.addRepositoryToConfig).toHaveBeenCalledWith('testuser', 'testrepo', 'test.md', 'custom-name', undefined, 'main', undefined, true);
+      expect(mockedConfig.addRepositoryToConfig).toHaveBeenCalledWith('testuser', 'testrepo', 'test.md', 'custom-name', null, 'main', null, true);
       expect(consoleSpy).toHaveBeenCalledWith("✓ Successfully installed command 'custom-name' to /test/commands/testuser/testrepo/custom-name.md");
     });
 
@@ -88,23 +88,16 @@ describe('Add Command', () => {
       await addCommand('testuser/testrepo/test', options);
 
       expect(mockedPaths.ensureCommandsDir).toHaveBeenCalledWith(false);
-      expect(mockedConfig.addRepositoryToConfig).toHaveBeenCalledWith('testuser', 'testrepo', 'test.md', undefined, undefined, 'main', undefined, false);
+      expect(mockedConfig.addRepositoryToConfig).toHaveBeenCalledWith('testuser', 'testrepo', 'test.md', undefined, null, 'main', null, false);
     });
 
-    test('should add command with version constraint', async () => {
-      const options = { global: false, version: '1.0.0' };
-
-      await addCommand('testuser/testrepo/test', options);
-
-      expect(mockedConfig.addRepositoryToConfig).toHaveBeenCalledWith('testuser', 'testrepo', 'test.md', undefined, '1.0.0', undefined, undefined, true);
-    });
 
     test('should add command with branch constraint', async () => {
       const options = { global: false, branch: 'develop' };
 
       await addCommand('testuser/testrepo/test', options);
 
-      expect(mockedConfig.addRepositoryToConfig).toHaveBeenCalledWith('testuser', 'testrepo', 'test.md', undefined, undefined, 'develop', undefined, true);
+      expect(mockedConfig.addRepositoryToConfig).toHaveBeenCalledWith('testuser', 'testrepo', 'test.md', undefined, null, 'develop', null, true);
     });
 
     test('should add all commands from repository', async () => {

--- a/tests/utils/config.test.js
+++ b/tests/utils/config.test.js
@@ -166,12 +166,12 @@ describe('Config Utils', () => {
       mockedFs.readJson.mockResolvedValue(existingConfig);
       mockedFs.writeJson.mockResolvedValue();
 
-      await addRepositoryToConfig('user', 'repo', null, null, '1.0.0', null, null, false);
+      await addRepositoryToConfig('user', 'repo', null, null, null, 'main', null, false);
 
       expect(mockedFs.writeJson).toHaveBeenCalledWith('/test/jumon.json', {
         repositories: {
           'user/repo': {
-            version: '1.0.0',
+            branch: 'main',
             only: []
           }
         }
@@ -206,20 +206,19 @@ describe('Config Utils', () => {
       }, { spaces: 2 });
     });
 
-    test('should handle version/branch/tag precedence', async () => {
+    test('should handle branch constraint', async () => {
       const existingConfig = { repositories: {} };
       
       mockedFs.pathExists.mockResolvedValue(true);
       mockedFs.readJson.mockResolvedValue(existingConfig);
       mockedFs.writeJson.mockResolvedValue();
 
-      // Version should take precedence
-      await addRepositoryToConfig('user', 'repo', null, null, '1.0.0', 'main', 'v1.0.0', true);
+      await addRepositoryToConfig('user', 'repo', null, null, null, 'develop', null, true);
 
       expect(mockedFs.writeJson).toHaveBeenCalledWith('/test/jumon.json', {
         repositories: {
           'user/repo': {
-            version: '1.0.0',
+            branch: 'develop',
             only: []
           }
         }


### PR DESCRIPTION
## Summary
- Remove --version and --tag command line options from add command
- Simplify addRepositoryToConfig to only handle branch constraints  
- Update related tests to match new simplified implementation

## Test plan
- [x] All existing tests pass
- [x] Removed version constraint test case
- [x] Updated test expectations to use null for version/tag parameters
- [x] Verified branch-only functionality works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)